### PR TITLE
Refresh dashboard and header design

### DIFF
--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -7,7 +7,7 @@ import {
   FiTrash2,
   FiPlus,
   FiEdit,
-  FiX,
+  FiLoader,
   FiCheck,
   FiSquare,
   FiCheckSquare
@@ -213,9 +213,9 @@ export default function Dashboard() {
 
   /* ————————————————— JSX ————————————————— */
   return (
-    <div className="flex min-h-screen bg-gray-900 text-gray-100 font-[Beiruti]">
+    <div className="flex min-h-screen bg-gray-50 text-gray-900 font-[Beiruti]">
       {/* ——— القائمة الجانبية ——— */}
-      <aside className="w-64 bg-gray-800 p-6 shadow-lg">
+      <aside className="w-64 bg-white p-6 shadow-lg border-r border-gray-200">
         <h2 className="text-2xl font-bold mb-6 text-center">القائمة</h2>
         <ul className="space-y-4">
           <li>
@@ -224,7 +224,7 @@ export default function Dashboard() {
               className={`w-full text-right px-4 py-2 rounded-lg transition ${
                 activeSection === 'categories'
                   ? 'bg-indigo-600 text-white shadow-xl'
-                  : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+                  : 'text-gray-700 hover:bg-gray-100'
               }`}
             >
               أقسام مهاراتي
@@ -236,7 +236,7 @@ export default function Dashboard() {
               className={`w-full text-right px-4 py-2 rounded-lg transition ${
                 activeSection === 'upload'
                   ? 'bg-indigo-600 text-white shadow-xl'
-                  : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+                  : 'text-gray-700 hover:bg-gray-100'
               }`}
             >
               رفع الصور
@@ -247,7 +247,10 @@ export default function Dashboard() {
 
       {/* ——— المحتوى الرئيسي ——— */}
       <main className="flex-1 p-10 space-y-10">
-        <h1 className="text-3xl font-bold text-center">لوحة التحكم</h1>
+        <div className="flex justify-between items-center">
+          <h1 className="text-3xl font-bold">لوحة التحكم</h1>
+          <a href="/" className="text-indigo-600 hover:underline">العودة للموقع</a>
+        </div>
 
         {/* ——— قسم الأقسام ——— */}
         {activeSection === 'categories' && (
@@ -257,7 +260,7 @@ export default function Dashboard() {
             className="space-y-10"
           >
             {/* إنشاء قسم جديد */}
-            <div className="bg-gray-800 rounded-2xl p-6 space-y-4 shadow-xl">
+            <div className="bg-white rounded-2xl p-6 space-y-4 shadow-xl">
               <h2 className="text-2xl font-semibold">إنشاء قسم جديد</h2>
               <div className="flex flex-col md:flex-row gap-4">
                 <input
@@ -265,9 +268,9 @@ export default function Dashboard() {
                   placeholder="اسم القسم"
                   value={newName}
                   onChange={e => setNewName(e.target.value)}
-                  className="bg-gray-700 border border-gray-600 rounded-lg p-2 flex-1 text-gray-100 placeholder-gray-400"
+                  className="bg-gray-100 border border-gray-300 rounded-lg p-2 flex-1 text-gray-900 placeholder-gray-500"
                 />
-                <label className="flex items-center gap-2 cursor-pointer text-gray-200">
+                <label className="flex items-center gap-2 cursor-pointer text-gray-600">
                   <FiFile /> غلاف
                   <input type="file" accept="image/*" hidden onChange={handleNewCover} />
                 </label>
@@ -291,22 +294,22 @@ export default function Dashboard() {
             </div>
 
             {/* الأقسام الحالية */}
-            <div className="bg-gray-800 rounded-2xl p-6 space-y-4 shadow-xl">
+            <div className="bg-white rounded-2xl p-6 space-y-4 shadow-xl">
               <h2 className="text-2xl font-semibold">الأقسام الحالية</h2>
               {loadingCats ? (
                 <div className="flex gap-4">
                   {[...Array(2)].map((_, i) => (
-                    <div key={i} className="w-32 h-32 bg-gray-700 animate-pulse rounded-lg" />
+                    <div key={i} className="w-32 h-32 bg-gray-200 animate-pulse rounded-lg" />
                   ))}
                 </div>
               ) : categories.length === 0 ? (
-                <p className="text-gray-400">لا توجد أقسام.</p>
+                <p className="text-gray-500">لا توجد أقسام.</p>
               ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
                   {categories.map(c => (
                     <div
                       key={c.id}
-                      className="bg-gray-800 border border-gray-700 rounded-2xl p-5 relative shadow-md hover:shadow-lg transition"
+                      className="bg-white border border-gray-300 rounded-2xl p-5 relative shadow-md hover:shadow-lg transition"
                     >
                       {editId === c.id ? (
                         <>
@@ -314,9 +317,9 @@ export default function Dashboard() {
                             type="text"
                             value={editName}
                             onChange={e => setEditName(e.target.value)}
-                            className="w-full mb-2 p-2 rounded-lg bg-gray-700 text-gray-100 border border-gray-600"
+                            className="w-full mb-2 p-2 rounded-lg bg-gray-100 text-gray-900 border border-gray-300"
                           />
-                          <label className="flex items-center gap-2 mb-2 cursor-pointer text-gray-200">
+                          <label className="flex items-center gap-2 mb-2 cursor-pointer text-gray-600">
                             <FiFile /> غلاف جديد
                             <input type="file" accept="image/*" hidden onChange={handleEditCover} />
                           </label>
@@ -356,7 +359,7 @@ export default function Dashboard() {
                               />
                             </div>
                           )}
-                          <p className="font-medium mb-4 text-gray-100">{c.name}</p>
+                          <p className="font-medium mb-4 text-gray-800">{c.name}</p>
                           <div className="flex justify-end gap-3">
                             <button
                               onClick={() => startEdit(c)}
@@ -389,16 +392,16 @@ export default function Dashboard() {
             className="space-y-10"
           >
             {/* رفع جديد */}
-            <div className="bg-gray-800 rounded-2xl p-6 space-y-4 shadow-xl">
+            <div className="bg-white rounded-2xl p-6 space-y-4 shadow-xl">
               <h2 className="text-2xl font-semibold">رفع صور</h2>
 
               {/* التحكم في القسم (اختياري للواجهة فقط) */}
               <div className="flex items-center gap-4">
-                <label className="text-gray-200">اختر القسم:</label>
+                <label className="text-gray-700">اختر القسم:</label>
                 <select
                   value={categoryForUpload}
                   onChange={e => setCategoryForUpload(e.target.value)}
-                  className="bg-gray-700 border border-gray-600 rounded-lg p-2 text-gray-100"
+                  className="bg-gray-100 border border-gray-300 rounded-lg p-2 text-gray-900"
                 >
                   <option value="skills">أقسام مهاراتي</option>
                   <option value="logos">شعارات بنيتها</option>
@@ -406,7 +409,7 @@ export default function Dashboard() {
               </div>
 
               <div className="flex items-center gap-4">
-                <label className="flex-1 flex items-center justify-center gap-3 cursor-pointer bg-gray-700 border border-gray-600 rounded-lg py-3 hover:bg-gray-600">
+                <label className="flex-1 flex items-center justify-center gap-3 cursor-pointer bg-gray-100 border border-gray-300 rounded-lg py-3 hover:bg-gray-200">
                   <FiFile /> اختر ملفات
                   <input
                     ref={inputRef}
@@ -423,7 +426,7 @@ export default function Dashboard() {
                   disabled={uploading || !files.length}
                   className="w-16 h-16 bg-indigo-500 hover:bg-indigo-400 text-white rounded-lg flex items-center justify-center"
                 >
-                  {uploading ? <FiX className="animate-spin" /> : <FiUpload size={24} />}
+                  {uploading ? <FiLoader className="animate-spin" /> : <FiUpload size={24} />}
                 </button>
               </div>
 
@@ -444,7 +447,7 @@ export default function Dashboard() {
             </div>
 
             {/* الصور المخزنة */}
-            <div className="bg-gray-800 rounded-2xl p-6 space-y-4 shadow-xl">
+            <div className="bg-white rounded-2xl p-6 space-y-4 shadow-xl">
               <div className="flex justify-between items-center">
                 <h2 className="text-2xl font-semibold">الصور المخزنة</h2>
                 <div className="flex gap-2">
@@ -468,7 +471,7 @@ export default function Dashboard() {
               {loadingImgs ? (
                 <div className="grid grid-cols-3 gap-4">
                   {[...Array(3)].map((_, i) => (
-                    <div key={i} className="h-32 bg-gray-700 animate-pulse rounded-lg" />
+                    <div key={i} className="h-32 bg-gray-200 animate-pulse rounded-lg" />
                   ))}
                 </div>
               ) : images.length === 0 ? (
@@ -517,12 +520,12 @@ export default function Dashboard() {
         {/* ——— نافذة تأكيد الحذف ——— */}
         {showModal && (
           <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center">
-            <div className="bg-gray-800 p-6 rounded-2xl shadow-2xl w-80 text-right space-y-4">
-              <p className="text-gray-100">هل أنت متأكد من حذف الصور المحددة؟</p>
+            <div className="bg-white p-6 rounded-2xl shadow-2xl w-80 text-right space-y-4">
+              <p className="text-gray-700">هل أنت متأكد من حذف الصور المحددة؟</p>
               <div className="flex justify-end gap-3">
                 <button
                   onClick={() => setShowModal(false)}
-                  className="px-4 py-2 border border-gray-600 rounded-lg text-gray-200"
+                  className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700"
                 >
                   إلغاء
                 </button>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -156,7 +156,7 @@ export default function Home() {
       <GlobalCSS />
 
       {/* Header with mobile sidebar toggle */}
-      <header className="flex-none bg-white border-b border-gray-200">
+      <header className="flex-none bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white">
         <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-4 flex items-center justify-between">
           {/* Logo */}
           <div className="flex items-center text-right space-x-2 rtl:space-x-reverse">
@@ -165,12 +165,12 @@ export default function Home() {
           </div>
 
           {/* Desktop nav + button */}
-          <nav className="hidden md:flex items-center space-x-6 text-lg text-gray-700 rtl:space-x-reverse">
-            <a href="#" className="hover:text-gray-900">اطلب تصميمك</a>
-            <a href="#" className="hover:text-gray-900">اتصل بعمر مباشرة</a>
-            <a href="#" className="hover:text-gray-900">اسأل سؤالك</a>
-            <a href="#" className="hover:text-gray-900">حسابات عمر</a>
-            <a href="#" className="hover:text-gray-900">نبذة عن عمر</a>
+          <nav className="hidden md:flex items-center space-x-6 text-lg text-white rtl:space-x-reverse">
+            <a href="#" className="hover:text-gray-200">اطلب تصميمك</a>
+            <a href="#" className="hover:text-gray-200">اتصل بعمر مباشرة</a>
+            <a href="#" className="hover:text-gray-200">اسأل سؤالك</a>
+            <a href="#" className="hover:text-gray-200">حسابات عمر</a>
+            <a href="#" className="hover:text-gray-200">نبذة عن عمر</a>
             <button className="px-6 py-2 bg-black text-white font-medium rounded-full shadow hover:opacity-90 active:opacity-80 transition">
               تواصل معي
             </button>
@@ -181,7 +181,7 @@ export default function Home() {
             <a href="tel:+123456789" className="p-3 bg-black text-white rounded-full shake text-xl hover:opacity-90 transition">
               <FiPhoneCall />
             </a>
-            <button onClick={() => setMenuOpen(true)} className="text-2xl text-gray-700 hover:text-gray-900">
+            <button onClick={() => setMenuOpen(true)} className="text-2xl text-white hover:text-gray-200">
               <FiMenu />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- lighten the dashboard style and add a link back to the site
- use `FiLoader` icon while uploading
- add a gradient header to the home page
- adjust header nav colors

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434654f47c8321a36de994a104dc1e