### PR TITLE
Implement secure dashboard login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for the dashboard login
+# Salt used for password hashing
+ADMIN_SALT=replace_with_random_salt
+# Hex encoded PBKDF2 hash of the admin password
+ADMIN_HASH=replace_with_hash
+# Secret key for signing session cookies
+SESSION_SECRET=replace_with_session_secret

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+
+## Dashboard Authentication
+
+The dashboard is protected by a simple password-based login. To enable it, create a `.env.local` file based on `.env.example` and provide the following variables:
+
+```
+ADMIN_SALT=your_unique_salt
+ADMIN_HASH=pbkdf2_hash_of_password
+SESSION_SECRET=random_session_secret
+```
+
+The password field is hashed using PBKDF2 and compared with `ADMIN_HASH`. A signed HTTP-only cookie is issued upon successful login and checked on each dashboard request.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+
+const SESSION_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export function createSessionToken() {
+  const expires = Date.now() + SESSION_AGE_MS;
+  const token = `${expires}:${crypto.randomBytes(32).toString('hex')}`;
+  const sig = crypto.createHmac('sha256', process.env.SESSION_SECRET)
+    .update(token)
+    .digest('hex');
+  return `${token}.${sig}`;
+}
+
+export function verifySession(req) {
+  const cookie = req.headers.cookie
+    ?.split(';')
+    .find(c => c.trim().startsWith('session='));
+  if (!cookie) return false;
+  const raw = cookie.trim().slice('session='.length);
+  const [token, sig] = raw.split('.');
+  if (!token || !sig) return false;
+
+  const expectedSig = crypto
+    .createHmac('sha256', process.env.SESSION_SECRET)
+    .update(token)
+    .digest('hex');
+  if (sig.length !== expectedSig.length) return false;
+  const validSig = crypto.timingSafeEqual(
+    Buffer.from(sig, 'hex'),
+    Buffer.from(expectedSig, 'hex')
+  );
+  if (!validSig) return false;
+
+  const [expiresStr] = token.split(':');
+  const expires = parseInt(expiresStr, 10);
+  if (Number.isNaN(expires) || Date.now() > expires) return false;
+
+  return true;
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+import { createSessionToken } from '../../lib/auth';
+
+const ITERATIONS = 100000;
+const KEY_LEN = 64;
+const DIGEST = 'sha512';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end();
+  }
+
+  const { password } = req.body;
+  if (typeof password !== 'string') {
+    return res.status(400).json({ error: 'missing-password' });
+  }
+
+  const hash = crypto
+    .pbkdf2Sync(password, process.env.ADMIN_SALT, ITERATIONS, KEY_LEN, DIGEST)
+    .toString('hex');
+  const expected = process.env.ADMIN_HASH;
+  if (!expected || hash.length !== expected.length) {
+    return res.status(401).json({ error: 'invalid-password' });
+  }
+  const valid = crypto.timingSafeEqual(
+    Buffer.from(hash, 'hex'),
+    Buffer.from(expected, 'hex')
+  );
+  if (!valid) {
+    return res.status(401).json({ error: 'invalid-password' });
+  }
+
+  const token = createSessionToken();
+  const prod = process.env.NODE_ENV === 'production';
+  res.setHeader(
+    'Set-Cookie',
+    `session=${token}; HttpOnly; Path=/; SameSite=Strict; Max-Age=3600;${prod ? ' Secure;' : ''}`
+  );
+
+  return res.status(200).json({ ok: true });
+}

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  const prod = process.env.NODE_ENV === 'production';
+  res.setHeader(
+    'Set-Cookie',
+    `session=; HttpOnly; Path=/; Max-Age=0; SameSite=Strict;${prod ? ' Secure;' : ''}`
+  );
+  res.status(200).json({ ok: true });
+}

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -1,5 +1,6 @@
 // File: pages/dashboard.jsx
 import React, { useState, useEffect, useRef } from 'react';
+import { verifySession } from '../lib/auth';
 import { motion } from 'framer-motion';
 import {
   FiUpload,
@@ -211,6 +212,11 @@ export default function Dashboard() {
     fetchImgs();
   };
 
+  const handleLogout = async () => {
+    await fetch('/api/logout');
+    window.location.href = '/login';
+  };
+
   /* ————————————————— JSX ————————————————— */
   return (
     <div className="flex min-h-screen bg-gray-900 text-gray-100 font-[Beiruti]">
@@ -240,6 +246,14 @@ export default function Dashboard() {
               }`}
             >
               رفع الصور
+            </button>
+          </li>
+          <li>
+            <button
+              onClick={handleLogout}
+              className="w-full text-right px-4 py-2 rounded-lg text-gray-300 hover:bg-gray-700 hover:text-white"
+            >
+              تسجيل الخروج
             </button>
           </li>
         </ul>
@@ -546,4 +560,13 @@ export default function Dashboard() {
       </main>
     </div>
   );
+}
+
+export async function getServerSideProps({ req }) {
+  if (!verifySession(req)) {
+    return {
+      redirect: { destination: '/login', permanent: false }
+    };
+  }
+  return { props: {} };
 }

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password })
+    });
+    if (res.ok) {
+      router.push('/dashboard');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || 'فشل تسجيل الدخول');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-900">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-gray-800 p-8 rounded-lg space-y-4 shadow-md"
+      >
+        <h1 className="text-2xl font-bold text-white text-center">تسجيل الدخول</h1>
+        <input
+          type="password"
+          className="w-full p-2 rounded bg-gray-700 text-gray-100"
+          placeholder="كلمة المرور"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button
+          disabled={loading}
+          className="w-full bg-indigo-600 hover:bg-indigo-500 text-white p-2 rounded"
+        >
+          دخول
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add helper functions for session tokens in `lib/auth.js`
- implement `/api/login` and `/api/logout` routes
- protect dashboard with `getServerSideProps`
- add login page and logout button
- document new authentication and environment variables

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845694ec5e883218a0120975722086b