### PR TITLE
Improve security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment configuration for the dashboard login
+# Salt used for password hashing
+ADMIN_SALT=replace_with_random_salt
+# Hex encoded PBKDF2 hash of the admin password "omar@44544"
+ADMIN_HASH=f58c2050e3c0022c1c565583637e19d6f5fc80220f81696cf40b98dfa541ea0b65d0e2f412d8be7296960ac4c5001c3b5e6e783644c98a30beaf992ed23ae06c
+# Username required to access the dashboard
+ADMIN_USERNAME=omaradmin
+# Secret key for signing session cookies
+SESSION_SECRET=replace_with_session_secret
+# Number of milliseconds for the rate limit window
+RATE_LIMIT_WINDOW=60000
+# Maximum login attempts allowed within the window
+RATE_LIMIT_MAX=5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies:
+
+```bash
+npm install
+```
+
+Then run the development server:
 
 ```bash
 npm run dev
@@ -38,3 +44,44 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+
+## Dashboard Authentication
+
+The dashboard is protected by a simple password-based login. To enable it, create a `.env.local` file based on `.env.example` and provide the following variables:
+
+```
+ADMIN_SALT=your_unique_salt
+ADMIN_HASH=pbkdf2_hash_of_omar@44544
+ADMIN_USERNAME=omaradmin
+SESSION_SECRET=random_session_secret
+RATE_LIMIT_WINDOW=60000
+RATE_LIMIT_MAX=5
+```
+
+The login page asks for both a username and password. The username should match
+`ADMIN_USERNAME` (default `omaradmin`). The password is hashed with PBKDF2 and
+compared with `ADMIN_HASH`. A signed HTTP-only cookie is issued upon successful
+login and checked on each dashboard request.
+
+Before submitting credentials, the page fetches a CSRF token from `/api/csrf`.
+The token is stored in a cookie and sent back in an `X-CSRF-Token` header when
+logging in. The login API verifies this token to prevent cross-site request
+forgery.
+
+You can generate a PBKDF2 hash for a new password using:
+
+```bash
+node scripts/hash.js mypassword mysalt
+```
+
+## Security Headers
+
+The app uses a [`middleware.js`](middleware.js) file to set common security headers for all responses, including:
+
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: same-origin`
+- `Content-Security-Policy: default-src 'self'; img-src 'self' data:; object-src 'none'`
+- `Strict-Transport-Security` in production
+
+These headers help mitigate clickjacking, MIME sniffing, and other common attacks.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+
+const SESSION_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export function createSessionToken() {
+  const expires = Date.now() + SESSION_AGE_MS;
+  const token = `${expires}:${crypto.randomBytes(32).toString('hex')}`;
+  const sig = crypto.createHmac('sha256', process.env.SESSION_SECRET)
+    .update(token)
+    .digest('hex');
+  return `${token}.${sig}`;
+}
+
+export function verifySession(req) {
+  const cookie = req.headers.cookie
+    ?.split(';')
+    .find(c => c.trim().startsWith('session='));
+  if (!cookie) return false;
+  const raw = cookie.trim().slice('session='.length);
+  const [token, sig] = raw.split('.');
+  if (!token || !sig) return false;
+
+  const expectedSig = crypto
+    .createHmac('sha256', process.env.SESSION_SECRET)
+    .update(token)
+    .digest('hex');
+  if (sig.length !== expectedSig.length) return false;
+  const validSig = crypto.timingSafeEqual(
+    Buffer.from(sig, 'hex'),
+    Buffer.from(expectedSig, 'hex')
+  );
+  if (!validSig) return false;
+
+  const [expiresStr] = token.split(':');
+  const expires = parseInt(expiresStr, 10);
+  if (Number.isNaN(expires) || Date.now() > expires) return false;
+
+  return true;
+}

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -1,0 +1,27 @@
+import crypto from 'crypto'
+
+export function createCsrfToken() {
+  return crypto.randomBytes(32).toString('hex')
+}
+
+export function setCsrfCookie(res, token) {
+  const prod = process.env.NODE_ENV === 'production'
+  res.setHeader(
+    'Set-Cookie',
+    `csrf=${token}; Path=/; SameSite=Strict; Max-Age=3600;${prod ? ' Secure;' : ''}`
+  )
+}
+
+export function verifyCsrf(req) {
+  const cookie = req.headers.cookie
+    ?.split(';')
+    .find(c => c.trim().startsWith('csrf='))
+  if (!cookie) return false
+  const tokenInCookie = cookie.trim().slice('csrf='.length)
+  const headerToken = req.headers['x-csrf-token']
+  if (!headerToken || headerToken.length !== tokenInCookie.length) return false
+  return crypto.timingSafeEqual(
+    Buffer.from(headerToken),
+    Buffer.from(tokenInCookie)
+  )
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+export function middleware(req) {
+  const res = NextResponse.next()
+  res.headers.set('X-Frame-Options', 'DENY')
+  res.headers.set('X-Content-Type-Options', 'nosniff')
+  res.headers.set('Referrer-Policy', 'same-origin')
+  res.headers.set(
+    'Content-Security-Policy',
+    "default-src 'self'; img-src 'self' data:; object-src 'none'"
+  )
+  if (process.env.NODE_ENV === 'production') {
+    res.headers.set(
+      'Strict-Transport-Security',
+      'max-age=63072000; includeSubDomains; preload'
+    )
+  }
+  return res
+}
+
+export const config = {
+  matcher: '/:path*'
+}

--- a/pages/api/csrf.js
+++ b/pages/api/csrf.js
@@ -1,0 +1,7 @@
+import { createCsrfToken, setCsrfCookie } from '../../lib/csrf'
+
+export default function handler(req, res) {
+  const token = createCsrfToken()
+  setCsrfCookie(res, token)
+  res.status(200).json({ token })
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,83 @@
+import crypto from 'crypto';
+import { createSessionToken } from '../../lib/auth';
+import { verifyCsrf } from '../../lib/csrf';
+
+const ITERATIONS = 100000;
+const KEY_LEN = 64;
+const DIGEST = 'sha512';
+
+const RATE_LIMIT_WINDOW = parseInt(process.env.RATE_LIMIT_WINDOW || '60000', 10);
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX || '5', 10);
+const attempts = new Map();
+
+function recordAttempt(ip) {
+  const now = Date.now();
+  const entry = attempts.get(ip) || { count: 0, start: now };
+  if (now - entry.start > RATE_LIMIT_WINDOW) {
+    entry.count = 1;
+    entry.start = now;
+  } else {
+    entry.count += 1;
+  }
+  attempts.set(ip, entry);
+  return entry.count > RATE_LIMIT_MAX;
+}
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end();
+  }
+
+  if (!verifyCsrf(req)) {
+    return res.status(403).json({ error: 'invalid-csrf' });
+  }
+
+  const ip =
+    req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress;
+  if (recordAttempt(ip)) {
+    return res.status(429).json({ error: 'too-many-attempts' });
+  }
+
+  const { username, password } = req.body;
+  if (typeof username !== 'string' || typeof password !== 'string') {
+    return res.status(400).json({ error: 'missing-credentials' });
+  }
+
+  const expectedUser = process.env.ADMIN_USERNAME || 'omaradmin';
+  const userMatch =
+    username.length === expectedUser.length &&
+    crypto.timingSafeEqual(
+      Buffer.from(username),
+      Buffer.from(expectedUser)
+    );
+  if (!userMatch) {
+    return res.status(401).json({ error: 'invalid-username' });
+  }
+
+  const hash = crypto
+    .pbkdf2Sync(password, process.env.ADMIN_SALT, ITERATIONS, KEY_LEN, DIGEST)
+    .toString('hex');
+  const expected = process.env.ADMIN_HASH;
+  if (!expected || hash.length !== expected.length) {
+    return res.status(401).json({ error: 'invalid-password' });
+  }
+  const valid = crypto.timingSafeEqual(
+    Buffer.from(hash, 'hex'),
+    Buffer.from(expected, 'hex')
+  );
+  if (!valid) {
+    return res.status(401).json({ error: 'invalid-password' });
+  }
+
+  const token = createSessionToken();
+  const prod = process.env.NODE_ENV === 'production';
+  res.setHeader('Set-Cookie', [
+    `session=${token}; HttpOnly; Path=/; SameSite=Strict; Max-Age=3600;${prod ? ' Secure;' : ''}`,
+    `csrf=; Path=/; Max-Age=0; SameSite=Strict${prod ? '; Secure' : ''}`
+  ]);
+
+  attempts.delete(ip);
+
+  return res.status(200).json({ ok: true });
+}

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  const prod = process.env.NODE_ENV === 'production';
+  res.setHeader(
+    'Set-Cookie',
+    `session=; HttpOnly; Path=/; Max-Age=0; SameSite=Strict;${prod ? ' Secure;' : ''}`
+  );
+  res.status(200).json({ ok: true });
+}

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -1,5 +1,6 @@
 // File: pages/dashboard.jsx
 import React, { useState, useEffect, useRef } from 'react';
+import { verifySession } from '../lib/auth';
 import { motion } from 'framer-motion';
 import {
   FiUpload,
@@ -211,6 +212,11 @@ export default function Dashboard() {
     fetchImgs();
   };
 
+  const handleLogout = async () => {
+    await fetch('/api/logout');
+    window.location.href = '/login';
+  };
+
   /* ————————————————— JSX ————————————————— */
   return (
     <div className="flex min-h-screen bg-gray-900 text-gray-100 font-[Beiruti]">
@@ -240,6 +246,14 @@ export default function Dashboard() {
               }`}
             >
               رفع الصور
+            </button>
+          </li>
+          <li>
+            <button
+              onClick={handleLogout}
+              className="w-full text-right px-4 py-2 rounded-lg text-gray-300 hover:bg-gray-700 hover:text-white"
+            >
+              تسجيل الخروج
             </button>
           </li>
         </ul>
@@ -546,4 +560,13 @@ export default function Dashboard() {
       </main>
     </div>
   );
+}
+
+export async function getServerSideProps({ req }) {
+  if (!verifySession(req)) {
+    return {
+      redirect: { destination: '/login', permanent: false }
+    };
+  }
+  return { props: {} };
 }

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [csrfToken, setCsrfToken] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/csrf')
+      .then(res => res.json())
+      .then(data => setCsrfToken(data.token))
+      .catch(() => setCsrfToken(''))
+  }, [])
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
+      },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      router.push('/dashboard');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || 'فشل تسجيل الدخول');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-900">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-gray-800 p-8 rounded-lg space-y-4 shadow-md"
+      >
+        <h1 className="text-2xl font-bold text-white text-center">تسجيل الدخول</h1>
+        <input
+          type="text"
+          className="w-full p-2 rounded bg-gray-700 text-gray-100"
+          placeholder="اسم المستخدم"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="w-full p-2 rounded bg-gray-700 text-gray-100"
+          placeholder="كلمة المرور"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button
+          disabled={loading}
+          className="w-full bg-indigo-600 hover:bg-indigo-500 text-white p-2 rounded"
+        >
+          دخول
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const crypto = require('crypto');
+const [password, salt] = process.argv.slice(2);
+if (!password || !salt) {
+  console.error('Usage: node scripts/hash.js <password> <salt>');
+  process.exit(1);
+}
+const hash = crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
+console.log(hash);


### PR DESCRIPTION
## Summary
- add middleware with standard security headers
- document security headers in README
- implement CSRF protection for login

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845694ec5e883218a0120975722086b