### PR TITLE
Optimize images before storing

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -1,0 +1,9 @@
+import sharp from 'sharp';
+
+export default async function optimize(buffer) {
+  return sharp(buffer)
+    .rotate()
+    .resize({ width: 1280, withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toBuffer();
+}

--- a/pages/api/categories/[id].js
+++ b/pages/api/categories/[id].js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import multer from 'multer';
 import pool from '../../../lib/db';
+import optimize from '../../../lib/optimize';
 
 const upload = multer({ storage: multer.memoryStorage() });
 const handler = nextConnect();
@@ -28,8 +29,8 @@ handler.put(async (req, res) => {
 
   if (!name) return res.status(400).json({ error: 'name required' });
 
-  const cover = req.file ? req.file.buffer   : null;
-  const cType = req.file ? req.file.mimetype : null;
+  const cover = req.file ? await optimize(req.file.buffer) : null;
+  const cType = req.file ? 'image/webp' : null;
 
   const r = await pool.query(
   'UPDATE categories SET name=$1, cover=COALESCE($2,cover), cover_type=COALESCE($3,cover_type) WHERE id=$4 RETURNING id',

--- a/pages/api/categories/[id]/images.js
+++ b/pages/api/categories/[id]/images.js
@@ -1,83 +1,48 @@
 import nextConnect from 'next-connect';
-import multer      from 'multer';
-import pool        from '../../../../lib/db';   // ملاحظة مسار الرجوع ../..
-const util = require('util');
+import multer from 'multer';
+import pool from '../../../../lib/db';
+import optimize from '../../../../lib/optimize';
 
-const upload  = multer({ storage: multer.memoryStorage() });
+const upload = multer({ storage: multer.memoryStorage() });
 const handler = nextConnect();
 
-/* ———ـ جلب صور قسم واحد ———ـ */
 handler.get(async (req, res) => {
-  const { id }   = req.query;
+  const { id } = req.query;
   const { rows } = await pool.query(
     'SELECT id, data, content_type FROM images WHERE category_id=$1 ORDER BY id DESC',
     [id]
   );
   const imgs = rows.map(r => ({
-    id : r.id,
+    id: r.id,
     src: `data:${r.content_type};base64,${r.data.toString('base64')}`
   }));
   res.json(imgs);
 });
 
-/* ———ـ رفع صورة جديدة ———ـ */
-handler.use(upload.single('file'));          // المفتاح «file» هو نفسه الذى ترسله الواجهة\:contentReference[oaicite:5]{index=5}
+handler.use(upload.single('file'));
 
 handler.post(async (req, res) => {
-    console.log('🔵 POST-HIT post1');               // لتتأكد أنّ الطلب وصل
-  const { id }   = req.query;
-  const cover   = req?.file ? req?.file?.buffer   : null;
-  const cType   = req?.file ? req?.file?.mimetype : null;
-console.log(util.inspect(req, { showHidden: false, depth: null, colors: true }));
-  console.log('🔵 POST-HIT 1 '+ req.cat);               // لتتأكد أنّ الطلب وصل
+  try {
+    const { id } = req.query;
+    if (!req.file) return res.status(400).json({ error: 'no-file' });
 
-  await pool.query(
-    'INSERT INTO images (data, content_type, category_id) VALUES ($1,$2,$3)',
-    [cover, cType, id]
-  );
-  res.status(201).json({ ok: true });
+    const optimized = await optimize(req.file.buffer);
+    await pool.query(
+      'INSERT INTO images (data, content_type, category_id) VALUES ($1,$2,$3)',
+      [optimized, 'image/webp', id]
+    );
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'server-error' });
+  }
 });
 
-/* ———ـ حذف صورة ———ـ (اختياري) */
 handler.delete(async (req, res) => {
-  const { img } = req.query;                // ?img=123
+  const { img } = req.query;
   await pool.query('DELETE FROM images WHERE id=$1', [img]);
   res.json({ ok: true });
 });
 
-export const config = { api: { bodyParser: false } };  // لازم لتعطيل بارسر Next.js
+export const config = { api: { bodyParser: false } };
 export default handler;
-
-handler.post(async (req, res) => {
-  console.log('🔵 POST-HIT post2');               // لتتأكد أنّ الطلب وصل
-
-  try {
-    if (!req.file) {
-      return res.status(400).json({ error: 'no-file' });
-    }
-
-    const { id } = req.query;                      // category_id
-    const {
-      buffer,           // بيانات الصورة
-      mimetype,         // image/jpeg …
-      originalname      // اسم الملف الأصلي
-    } = req.file;
-
-    const fileName = originalname ?? randomUUID(); // يعوّض عمود name
-
-    await pool.query(
-      `INSERT INTO images (name, img, img_type, category_id)
-       VALUES ($1, $2, $3, $4)`,
-      [fileName, buffer, mimetype, id]
-    );
-
-    return res.status(201).json({ ok: true });
-  } catch (err) {
-    // يطبع كامل الـ Stack Trace
-    console.error('🚨 IMAGE-UPLOAD-ERR:\n', err.stack || err);
-    return res.status(500).json({ error: 'server-error' });
-  }
-});
-
-
-// KMKFLDMVLKMFV

--- a/pages/api/categories/index.js
+++ b/pages/api/categories/index.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import multer from 'multer';
 import pool from '../../../lib/db';
+import optimize from '../../../lib/optimize';
 
 const upload = multer({ storage: multer.memoryStorage() });
 const handler = nextConnect();
@@ -25,8 +26,8 @@ handler.post(async (req, res) => {
   const { name } = req.body;
   if (!name) return res.status(400).json({ error: 'name-required' });
 
-  const cover   = req.file ? req.file.buffer   : null;
-  const cType   = req.file ? req.file.mimetype : null;
+  const cover   = req.file ? await optimize(req.file.buffer) : null;
+  const cType   = req.file ? 'image/webp' : null;
 
   const r = await pool.query(
     'INSERT INTO categories (name, cover, cover_type) VALUES ($1,$2,$3) RETURNING id',


### PR DESCRIPTION
## Summary
- add `lib/optimize.js` with a Sharp-based optimizer
- compress uploaded category covers and gallery images
- use optimized images in upload endpoint
- clean up and standardize gallery image API

## Testing
- `npm install` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f132cd7c832184d30174e972a090