### PR TITLE
Configure Supabase client via env vars

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,8 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL || 'https://lxkuvojqpgczvovcvwfw.supabase.co';
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx4a3V2b2pxcGdjenZvdmN2d2Z3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0MTU1MzEsImV4cCI6MjA2NDk5MTUzMX0.xDj9eFP_R9c2sz41ObODYNJmlBGt1Vt-rXDBIFOXZ2E';
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-export default supabase;
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/pages/api/categories/[id].js
+++ b/pages/api/categories/[id].js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
 import multer from 'multer';
-import supabase from '../../../lib/supabase';
+import { supabase } from '../../../lib/supabase';
 import toBase64 from '../../../lib/b64';
 
 const upload = multer({ storage: multer.memoryStorage() });

--- a/pages/api/categories/[id]/images.js
+++ b/pages/api/categories/[id]/images.js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
 import multer      from 'multer';
-import supabase    from '../../../../lib/supabase';
+import { supabase }    from '../../../../lib/supabase';
 import toBase64    from '../../../../lib/b64';
 const util = require('util');
 

--- a/pages/api/categories/index.js
+++ b/pages/api/categories/index.js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
 import multer from 'multer';
-import supabase from '../../../lib/supabase';
+import { supabase } from '../../../lib/supabase';
 import toBase64 from '../../../lib/b64';
 
 const upload = multer({ storage: multer.memoryStorage() });

--- a/pages/api/categories/index.js
+++ b/pages/api/categories/index.js
@@ -1,7 +1,12 @@
 import nextConnect from 'next-connect';
 import multer from 'multer';
-import { supabase } from '../../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
 import toBase64 from '../../../lib/b64';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
+);
 
 const upload = multer({ storage: multer.memoryStorage() });
 const handler = nextConnect();

--- a/pages/api/images.js
+++ b/pages/api/images.js
@@ -1,5 +1,5 @@
 // pages/api/images.js
-import supabase from '../../lib/supabase';
+import { supabase } from '../../lib/supabase';
 import toBase64 from '../../lib/b64';
 
 export default async function handler(req, res) {

--- a/pages/api/upload.js
+++ b/pages/api/upload.js
@@ -1,7 +1,7 @@
 // pages/api/upload.js
 import nextConnect from 'next-connect';
 import multer from 'multer';
-import supabase from '../../lib/supabase';
+import { supabase } from '../../lib/supabase';
 
 const upload = multer({ storage: multer.memoryStorage() });
 const handler = nextConnect();


### PR DESCRIPTION
## Summary
- configure Supabase client to use env vars instead of hardcoded values
- update API routes to import the named `supabase` export

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684607de1c9483218922c55a48953459